### PR TITLE
register relay and memory component

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaSetup.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaSetup.cs
@@ -325,6 +325,8 @@ namespace Barotrauma
 			UserData.RegisterType<ServerPacketHeader>();
 			UserData.RegisterType<ClientPacketHeader>();
 			UserData.RegisterType<DeliveryMethod>();
+			UserData.RegisterType<RelayComponent>();
+			UserData.RegisterType<MemoryComponent>();
 
 			AddCallMetaMember(UserData.RegisterType<Vector2>());
 			AddCallMetaMember(UserData.RegisterType<Vector3>());


### PR DESCRIPTION
whats the point of not registering like every class in barotrauma