### PR TITLE
move the registration of generic types to the lua side in a simple way

### DIFF
--- a/Barotrauma/BarotraumaShared/Lua/DefaultRegister.lua
+++ b/Barotrauma/BarotraumaShared/Lua/DefaultRegister.lua
@@ -114,6 +114,14 @@ RegisterBarotrauma("Camera")
 RegisterBarotrauma("InputType")
 RegisterBarotrauma("Key")
 
+RegisterBarotrauma("PrefabCollection`1[[Barotrauma.ItemPrefab]]")
+RegisterBarotrauma("PrefabCollection`1[[Barotrauma.JobPrefab]]")
+RegisterBarotrauma("PrefabCollection`1[[Barotrauma.CharacterPrefab]]")
+RegisterBarotrauma("PrefabCollection`1[[Barotrauma.AfflictionPrefab]]")
+RegisterBarotrauma("PrefabCollection`1[[Barotrauma.TalentPrefab]]")
+
+RegisterBarotrauma("Pair`2[[Barotrauma.JobPrefab],[System.Int32]]")
+
 AddCallMetaMember(RegisterBarotrauma("CharacterInfo"))
 AddCallMetaMember(RegisterBarotrauma("Items.Components.Signal"))
 AddCallMetaMember(RegisterBarotrauma("SubmarineInfo"))

--- a/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaSetup.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaSetup.cs
@@ -323,13 +323,7 @@ namespace Barotrauma
 			UserData.RegisterType<LuaHook.HookMethodType>();
 			UserData.RegisterType<IUserDataDescriptor>();
 
-			UserData.RegisterType<PrefabCollection<ItemPrefab>>();
-			UserData.RegisterType<PrefabCollection<JobPrefab>>();
-			UserData.RegisterType<PrefabCollection<CharacterPrefab>>();
-			UserData.RegisterType<PrefabCollection<AfflictionPrefab>>();
-			UserData.RegisterType<PrefabCollection<TalentPrefab>>();
 
-			UserData.RegisterType<Pair<JobPrefab, int>>();
 
 #if SERVER
 


### PR DESCRIPTION
It's easier to register by using such type names, and we can also register more complex types in this way, such as:

```
Type:
Dictionary<string,Dictionary<string,LuaHook.HookFunction[]>>

Type Name:
System.Collections.Generic.Dictionary`2[
    [
        System.String
    ],
    [
        System.Collections.Generic.Dictionary`2[
            [System.String],
            [Barotrauma.LuaSetup+LuaHook+HookFunction[]]
        ]
    ]
]
```


