### PR TITLE
Improve Harmony Hook

### DIFF
--- a/Barotrauma/BarotraumaShared/Lua/DefaultHook.lua
+++ b/Barotrauma/BarotraumaShared/Lua/DefaultHook.lua
@@ -1,36 +1,85 @@
 
-Hook.HookMethod("Barotrauma.Item", "TryInteract", function (instance, p)
-	if Hook.Call("itemInteract", instance, p.picker, p.ignoreRequiredItems, p.forceSelectKey, p.forceActionKey) == true then
-		return false
-	end
-end, Hook.HookMethodType.Before)
+Hook.HookMethod(
+	"Barotrauma.Item", "TryInteract",
+	{
+		"Barotrauma.Character",
+		"System.Boolean",
+		"System.Boolean",
+		"System.Boolean"
+	},
+	function (instance, p)
+		if Hook.Call("itemInteract", instance, p.picker, p.ignoreRequiredItems, p.forceSelectKey, p.forceActionKey) == true then
+			return false
+		end
+	end,
+	Hook.HookMethodType.Before
+)
 
-Hook.HookMethod("Barotrauma.Item", "ApplyTreatment", function (instance, p)
-	if Hook.Call("itemApplyTreatment", instance, p.user, p.character, p.targetLimb) then
-		return false
-	end
-end, Hook.HookMethodType.Before)
+Hook.HookMethod(
+	"Barotrauma.Item", "ApplyTreatment",
+	{
+		"Barotrauma.Character",
+		"Barotrauma.Character",
+		"Barotrauma.Limb"
+	},
+	function (instance, p)
+		if Hook.Call("itemApplyTreatment", instance, p.user, p.character, p.targetLimb) then
+			return false
+		end
+	end,
+	Hook.HookMethodType.Before
+)
 
-Hook.HookMethod("Barotrauma.Item", "Combine", function (instance, p)
-	if Hook.Call("itemCombine", instance, p.item, p.user) == true then
-		return false
-	end
-end, Hook.HookMethodType.Before)
+Hook.HookMethod(
+	"Barotrauma.Item", "Combine",
+	{
+		"Barotrauma.Item",
+		"Barotrauma.Character"
+	},
+	function (instance, p)
+		if Hook.Call("itemCombine", instance, p.item, p.user) == true then
+			return false
+		end
+	end,
+	Hook.HookMethodType.Before
+)
 
-Hook.HookMethod("Barotrauma.Item", "Drop", function (instance, p)
-	if Hook.Call("itemDrop", instance, p.dropper) == true then
-		return false
-	end
-end, Hook.HookMethodType.Before)
+Hook.HookMethod(
+	"Barotrauma.Item", "Drop",
+	{
+		"Barotrauma.Character",
+		"System.Boolean"
+	},
+	function (instance, p)
+		if Hook.Call("itemDrop", instance, p.dropper) == true then
+			return false
+		end
+	end,
+	Hook.HookMethodType.Before
+)
 
-Hook.HookMethod("Barotrauma.Item", "Equip", function (instance, p)
-	if Hook.Call("itemEquip", instance, p.character) == true then
-		return false
-	end
-end, Hook.HookMethodType.Before)
+Hook.HookMethod(
+	"Barotrauma.Item", "Equip",
+	{
+		"Barotrauma.Character"
+	},
+	function (instance, p)
+		if Hook.Call("itemEquip", instance, p.character) == true then
+			return false
+		end
+	end,
+	Hook.HookMethodType.Before
+)
 
-Hook.HookMethod("Barotrauma.Item", "Unequip", function (instance, p)
-	if Hook.Call("itemUnequip", instance, p.character) == true then
-		return false
-	end
-end, Hook.HookMethodType.Before)
+Hook.HookMethod(
+	"Barotrauma.Item", "Unequip",
+	{
+		"Barotrauma.Character"
+	},
+	function (instance, p)
+		if Hook.Call("itemUnequip", instance, p.character) == true then
+			return false
+		end
+	end,
+	Hook.HookMethodType.Before
+)


### PR DESCRIPTION
1. Hook.HookMethod can patch overloaded methods based on parameter types
2. Hook.HookMethod can add more patches to the method
3. Find all hook methods by the address of the function (origin method), not by the method path (string).
4. Fixed unable to add postfix patch to method (__params changed to __args)
5. Fix patching method will cause duplicate patches to be added

But be warned: since no one else seems to be using this feature right now, I have modified the parameter list of Hook.HookMethod.

I tested it for a while and everything seems to be working fine.

But I still don't know how to fix this bug:
1. Patch to Character.ApplyAttack
2. Attack a character
3. The game pops up Internal CLR error. (0x80131506) and crashes.