### PR TITLE
Potential solution for #46

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/ServerSettings.cs
@@ -489,8 +489,7 @@ namespace Barotrauma.Networking
                             DebugConsole.Command command = DebugConsole.FindCommand(commandName);
                             if (command == null)
                             {
-                                DebugConsole.ThrowError("Error in " + ClientPermissionsFile + " - \"" + commandName + "\" is not a valid console command.");
-                                continue;
+                                command = new DebugConsole.Command(commandName, "", (_) => {}, null, true);
                             }
 
                             permittedCommands.Add(command);

--- a/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaClasses.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaClasses.cs
@@ -507,6 +507,21 @@ namespace Barotrauma
 
 				luaAddedCommand.Add(cmd);
 				DebugConsole.Commands.Add(cmd);
+
+#if SERVER
+				foreach (var client in GameMain.Server.ConnectedClients) {
+					var index = client.PermittedConsoleCommands.FindIndex((pc) => pc.names[0] == cmd.names[0]);
+					if (index > -1) {
+						client.PermittedConsoleCommands[index] = cmd;
+					}
+				}
+				foreach (var permissions in GameMain.Server.ServerSettings.ClientPermissions) {
+					var index = permissions.PermittedCommands.FindIndex((pc) => pc.names[0] == cmd.names[0]);
+					if (index > -1) {
+						permissions.PermittedCommands[index] = cmd;
+					}
+				}
+#endif
 			}
 
 			public List<DebugConsole.Command> Commands => DebugConsole.Commands;


### PR DESCRIPTION
Unknown commands get added as individual commands without any effect. They are not added to the global command list, making them behave like non-existing commands, but without losing permission information.
Calling AddCommand from Lua now replaces commands for connected players and saved perms. This solves vanishing permissions and makes commands immediately useable after using the reloadlua command.

Downside: Server will no longer complain about actually unknown console commands.