### PR TITLE
Fix crash with some function hooks

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaCustomConverters.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaCustomConverters.cs
@@ -69,6 +69,23 @@ namespace Barotrauma
             {
                 return DynValue.NewString(v.ToString());
             });
+
+            Script.GlobalOptions.CustomConverters.SetScriptToClrCustomConversion(DataType.UserData, typeof(object), v =>
+            {
+                if (v.UserData.Object is LuaByte lbyte)
+                {
+                    return lbyte.Value;
+                }
+                else if (v.UserData.Object is LuaUShort lushort)
+                {
+                    return lushort.Value;
+                }
+                else if (v.UserData.Object is LuaFloat lfloat)
+                {
+                    return lfloat.Value;
+                }
+                return v.UserData.Object;
+            });
         }
 
         public static void RegisterAction<T>()


### PR DESCRIPTION
Hooking functions that return float, ushort or byte causes a crash as the returned value will not match the expected type.
This fix will allow to return LuaFloat, LuaByte and LuaUShort instead.
Example hook that would crash without this: ItemComponent.DegreeOfSuccess