### PR TITLE
Add AddLinked to MapEntity

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaBarotraumaAdditions.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Lua/LuaBarotraumaAdditions.cs
@@ -90,6 +90,14 @@ namespace Barotrauma
 		}
 	}
 
+	abstract partial class MapEntity 
+	{
+		public void AddLinked(MapEntity entity)
+		{
+			linkedTo.Add(entity);
+		}
+	}
+
 }
 
 namespace Barotrauma.Items.Components


### PR DESCRIPTION
MapEntity.linkedTo is readonly and arrives as a table on lua side, making it impossible to add new Links.

Introducing AddLinked as an Addition makes it possible to link things.