### PR TITLE
Alter logic related to `require()`

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Lua/LuaRequire.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Lua/LuaRequire.cs
@@ -1,0 +1,41 @@
+
+
+using System;
+using System.Collections.Generic;
+using MoonSharp.Interpreter;
+
+namespace Barotrauma
+{
+  class LuaRequire {
+    private Script lua { get; set; }
+    private Dictionary<Tuple<string, Table>, DynValue> LoadedModules { get; set; }
+
+    private bool GetExistingReturnValue(Tuple<string, Table> key, ref DynValue returnValue) {
+      return LoadedModules.TryGetValue(key, out returnValue);
+    }
+
+    private void ExecuteModule(Tuple<string, Table> key, ref DynValue returnValue) {
+      string moduleName = key.Item1;
+      Table globalContext = key.Item2;
+      returnValue = lua.Call(lua.RequireModule(moduleName, globalContext));
+      LoadedModules[key] = returnValue;
+    }
+
+    // Lua modules that have been previously loaded by require() will
+    // not be loaded again; instead, their initial return value is
+    // preserved and returned again on subsequent attempts.
+    public DynValue Require(string moduleName, Table globalContext) {
+      DynValue returnValue = DynValue.Nil;
+      var key = new Tuple<string, Table>(moduleName, globalContext);
+
+      if (GetExistingReturnValue(key, ref returnValue)) return returnValue;
+      ExecuteModule(key, ref returnValue);
+      return returnValue;
+    }
+
+    public LuaRequire(Script lua) {
+      this.lua = lua;
+      LoadedModules = new Dictionary<Tuple<string, Table>, DynValue>();
+    }
+  }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/LuaCsSetup.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/LuaCsSetup.cs
@@ -29,6 +29,7 @@ namespace Barotrauma
 		public LuaCsHook Hook { get; private set; }
 		public LuaCsNetworking Networking { get; private set; }
 		public LuaCsModStore ModStore { get; private set; }
+		private LuaRequire require { get; set; }
 
 		public CsScriptLoader NetScriptLoader { get; private set; }
 		public CsLua Lua { get; private set; }
@@ -236,22 +237,18 @@ namespace Barotrauma
 
 			return null;
 		}
-
-		private DynValue Require(string modname, Table globalContext)
+		public DynValue Require(string moduleName, Table globalContexts)
 		{
 			try
 			{
-				return lua.Call(lua.RequireModule(modname, globalContext));
-
+				return require.Require(moduleName, globalContexts);
 			}
 			catch (Exception e)
 			{
 				HandleException(e);
 			}
-
 			return null;
 		}
-
 		public object CallLuaFunction(object function, params object[] arguments)
 		{
 			try
@@ -309,6 +306,8 @@ namespace Barotrauma
 			lua.Options.ScriptLoader = LuaScriptLoader;
 			Lua = new CsLua(this);
 			CsScript = new CsScriptRunner(this);
+
+			require = new LuaRequire(lua);
 
 			Game = new LuaGame();
 			Networking = new LuaCsNetworking();


### PR DESCRIPTION
This is a new PR made after I closed https://github.com/evilfactory/Barotrauma-lua-attempt/pull/60 because I did not want to force push to my fork's master branch, and Github does not support changing the origin branch of a PR.

# ModLoader.lua

ModLoader.lua is altered so that the path for `require()` is set before any scripts are executed.

## Rationale
This will allow Lua mods to `require()` their own scripts during initialisation without relying on `dofile()`, and will allow Lua scripts to `require()` third-party scripts (e.g. submods, libraries) while being agnostic towards load order.

## Considerations
On its own, this should not alter the behaviour of any existing scripts. Possible edge case: see below.

# LuaCsSetup.cs

LuaCsSetup.cs is altered so that `Require(string, Table)` initially executes a Lua module and retains the return value, and passes the return value on subsequent calls for the same Lua module. A class and file named `LuaRequire` is added to encapsulate this logic.

## Rationale
This is to bring the behaviour of `Require(string, Table)` closer to the standard Lua specification for it. This will permit Lua `require()` to behave statically, especially when the returned value is a table or function (which behave as a wrapper for a pointer, causing all uses of `require()` to point to the same object).

This makes it much cleaner for a Lua mod to interact with its own components and with other Lua mods, and can allow Lua mods to completely avoid polluting the global scope.

## Considerations
Any scripts that make use of `require()` may run into unexpected behaviour if it does not expect the return value to behave statically (for example, multiple scripts `require()` a module that returns a reference type, like a table, and make modifications to it).

There could be a possible edge case combined with the change made in ModLoader.lua where a script `require()` a third-party module before that third-party module's parent mod has been initialised, and the return value is a reference type which begins to be altered before its intended initialisation (leading to unexpected behaviour).