### PR TITLE
Alter `LuaRequire`

### DIFF
--- a/Barotrauma/BarotraumaShared/Lua/ModLoader.lua
+++ b/Barotrauma/BarotraumaShared/Lua/ModLoader.lua
@@ -65,7 +65,10 @@ local function ExecutionQueue()
         while queue[1] ~= nil do
             RunFolder(
                 table.unpack(
-                    table.remove(queue)
+                    table.remove(
+                        queue,
+                        1
+                    )
                 )
             )
         end
@@ -83,7 +86,7 @@ local function ExecutionQueue()
     return queueExecutionFIFO, processQueueFIFO
 end
 
-local queueAutorun, processAutorun = ExecutionQueue()
+local queueAutorun,       processAutorun       = ExecutionQueue()
 local queueForcedAutorun, processForcedAutorun = ExecutionQueue()
 
 local function processPackages(packages, fn)


### PR DESCRIPTION
Class `LuaRequire` is altered:
* `require(mod)` now returns true if `mod` does not return any value (void) or returns `nil`. This is a Lua spec, see: https://www.lua.org/manual/5.2/manual.html#6.3.
* Executing a module with `require()` now also passes its content package path as an argument, which can be accessed with `local path = ...`. I did this because it seems that this project expects Lua scripts to be passed this as an argument when loaded.
  * This defaults to `null` if a content package path can't be found. The standard Lua module loader usually passes the script's path, but a script may struggle to tell the difference between this direct path and a content package path. Please make/suggest what change you think is best fit here.
* The load context (`Table globalContext`) is no longer part of the key in `loadedModules` and it's now only the module name.
* Improvements unrelated to functionality

ModLoader.lua is altered to fix the FIFO queue not being FIFO.

I have tested these changes to ensure that `require()` works as expected. I tested `local path = ...` for LocalMods on dedicated server but not for WorkshopMods.