### PR TITLE
Print exception stack trace in CsPackageManager.TryRun

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
@@ -830,8 +830,14 @@ public sealed class CsPackageManager : IDisposable
         }
         catch (Exception e)
         {
+            StackTrace st = new StackTrace(e);
+            String s = String.Join('\n',
+               st.GetFrames().SkipLast(1)
+               .Select(f => $"at {f.GetMethod().DeclaringType}.{f.GetMethod().Name}()")
+            );
+            
             ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Error while running {messageMethodName}() on plugin of type {messageTypeName}");
-            ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Details: {e}");
+            ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Details: {e.Message}\n{s}");
         }
     }
     

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -832,7 +833,7 @@ public sealed class CsPackageManager : IDisposable
         {
             StackTrace st = new StackTrace(e);
             String s = String.Join('\n',
-               st.GetFrames().SkipLast(1)
+               st.GetFrames().SkipLast(2)
                .Select(f => $"  at {f.GetMethod().DeclaringType}.{f.GetMethod().Name}()")
             );
             

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
@@ -831,7 +831,7 @@ public sealed class CsPackageManager : IDisposable
         catch (Exception e)
         {
             ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Error while running {messageMethodName}() on plugin of type {messageTypeName}");
-            ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Details: {e.Message} | {e.InnerException}");
+            ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Details: {e}");
         }
     }
     

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Plugins/CsPackageManager.cs
@@ -833,11 +833,14 @@ public sealed class CsPackageManager : IDisposable
             StackTrace st = new StackTrace(e);
             String s = String.Join('\n',
                st.GetFrames().SkipLast(1)
-               .Select(f => $"at {f.GetMethod().DeclaringType}.{f.GetMethod().Name}()")
+               .Select(f => $"  at {f.GetMethod().DeclaringType}.{f.GetMethod().Name}()")
             );
             
             ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Error while running {messageMethodName}() on plugin of type {messageTypeName}");
             ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Details: {e.Message}\n{s}");
+            if(e.InnerException != null){
+              ModUtils.Logging.PrintError($"{nameof(CsPackageManager)}: Inner Exception: {e.InnerException}");
+            }
         }
     }
     


### PR DESCRIPTION
This is not very helpful
![Screenshot_4](https://github.com/user-attachments/assets/b790d26f-143a-422d-8668-8e1f8f55e122)
I suggest replacing it with at least this
![Screenshot_3](https://github.com/user-attachments/assets/7f8f9dff-2d41-4e1c-98fe-e0e771d0ea57)
### Notes
You can just print e, but it's a bit ugly:
![Screenshot_5](https://github.com/user-attachments/assets/6dcf31f2-af67-41d6-8e88-533710c46ee5)
Idk how to capture line number
Also, in theory there's a simpler method:
```C#
StackTrace st = new StackTrace(e);
st = new StackTrace(st.GetFrames().SkipLast(1));
```
But it's not available in .NET 6 :BaroDev: