### PR TITLE
Added hooks to bypass some checks in console

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -2815,7 +2815,7 @@ namespace Barotrauma
                 passedCommandPermissionCheck = false;
             }
             
-            var bypass = GameMain.LuaCs.Hook.Call<bool?>("onConsoleCommand", client, splitCommand, passedConsolePermissionCheck, passedCommandPermissionCheck) ?? false;
+            var bypass = GameMain.LuaCs.Hook.Call<bool?>("onConsoleCommand", client, splitCommand, matchingCommand, passedConsolePermissionCheck, passedCommandPermissionCheck) ?? false;
             
             if (!bypass)
             {

--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -2810,12 +2810,12 @@ namespace Barotrauma
 
             string[] splitCommand = ToolBox.SplitCommand(command);
             Command matchingCommand = commands.Find(c => c.Names.Contains(splitCommand[0].ToIdentifier()));
-            if (matchingCommand != null && !client.PermittedConsoleCommands.Contains(matchingCommand) && client.Connection != GameMain.Server.OwnerConnection)
+            if (matchingCommand == null || !client.PermittedConsoleCommands.Contains(matchingCommand) && client.Connection != GameMain.Server.OwnerConnection)
             {
                 passedCommandPermissionCheck = false;
             }
             
-            var bypass = GameMain.LuaCs.Hook.Call<bool?>("console.bypassCommandPermissionCheck", client, splitCommand, passedConsolePermissionCheck, passedCommandPermissionCheck) ?? false;
+            var bypass = GameMain.LuaCs.Hook.Call<bool?>("onConsoleCommand", client, splitCommand, passedConsolePermissionCheck, passedCommandPermissionCheck) ?? false;
             
             if (!bypass)
             {

--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -2799,22 +2799,42 @@ namespace Barotrauma
         {
             if (GameMain.Server == null) return;
             if (string.IsNullOrWhiteSpace(command)) return;
+
+            var passedConsolePermissionCheck = true;
+            var passedCommandPermissionCheck = true;
+            
             if (!client.HasPermission(ClientPermissions.ConsoleCommands) && client.Connection != GameMain.Server.OwnerConnection)
             {
-                GameMain.Server.SendConsoleMessage("You are not permitted to use console commands!", client, Color.Red);
-                GameServer.Log(GameServer.ClientLogName(client) + " attempted to execute the console command \"" + command + "\" without a permission to use console commands.", ServerLog.MessageType.ConsoleUsage);
-                return;
+                passedConsolePermissionCheck = false;
             }
 
             string[] splitCommand = ToolBox.SplitCommand(command);
             Command matchingCommand = commands.Find(c => c.Names.Contains(splitCommand[0].ToIdentifier()));
             if (matchingCommand != null && !client.PermittedConsoleCommands.Contains(matchingCommand) && client.Connection != GameMain.Server.OwnerConnection)
             {
-                GameMain.Server.SendConsoleMessage("You are not permitted to use the command\"" + matchingCommand.Names[0] + "\"!", client, Color.Red);
-                GameServer.Log(GameServer.ClientLogName(client) + " attempted to execute the console command \"" + command + "\" without a permission to use the command.", ServerLog.MessageType.ConsoleUsage);
-                return;
+                passedCommandPermissionCheck = false;
             }
-            else if (matchingCommand == null)
+            
+            var bypass = GameMain.LuaCs.Hook.Call<bool?>("console.bypassCommandPermissionCheck", client, splitCommand, passedConsolePermissionCheck, passedCommandPermissionCheck) ?? false;
+            
+            if (!bypass)
+            {
+                if (!passedConsolePermissionCheck)
+                {
+                    GameMain.Server.SendConsoleMessage("You are not permitted to use console commands!", client, Color.Red);
+                    GameServer.Log(GameServer.ClientLogName(client) + " attempted to execute the console command \"" + command + "\" without a permission to use console commands.", ServerLog.MessageType.ConsoleUsage);
+                    return;
+                }
+
+                if (!passedCommandPermissionCheck)
+                {
+                    GameMain.Server.SendConsoleMessage("You are not permitted to use the command\"" + matchingCommand.Names[0] + "\"!", client, Color.Red);
+                    GameServer.Log(GameServer.ClientLogName(client) + " attempted to execute the console command \"" + command + "\" without a permission to use the command.", ServerLog.MessageType.ConsoleUsage);
+                    return;
+                }
+            }
+
+            if (matchingCommand == null)
             {
                 GameMain.Server.SendConsoleMessage("Command \"" + splitCommand[0] + "\" not found.", client, Color.Red);
                 return;

--- a/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
@@ -2429,7 +2429,7 @@ namespace Barotrauma
                 {
                     Command matchingCommand = commands.Find(c => c.Names.Contains(firstCommand));
 
-                    var bypass = GameMain.LuaCs.Hook.Call<bool?>("console.bypassClientSendCheck", firstCommand, matchingCommand) ?? false;
+                    var bypass = GameMain.LuaCs.Hook.Call<bool?>("onClientConsoleCommand", firstCommand, matchingCommand) ?? false;
                     if (matchingCommand == null || bypass)
                     {
                         //if the command is not defined client-side, we'll relay it anyway because it may be a custom command at the server's side

--- a/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
@@ -2429,7 +2429,7 @@ namespace Barotrauma
                 {
                     Command matchingCommand = commands.Find(c => c.Names.Contains(firstCommand));
 
-                    var bypass = GameMain.LuaCs.Hook.Call<bool?>("onClientConsoleCommand", firstCommand, matchingCommand) ?? false;
+                    var bypass = GameMain.LuaCs.Hook.Call<bool?>("onClientConsoleCommand", splitCommand, matchingCommand) ?? false;
                     if (matchingCommand == null || bypass)
                     {
                         //if the command is not defined client-side, we'll relay it anyway because it may be a custom command at the server's side

--- a/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
@@ -2428,7 +2428,9 @@ namespace Barotrauma
                 if (GameMain.Client != null)
                 {
                     Command matchingCommand = commands.Find(c => c.Names.Contains(firstCommand));
-                    if (matchingCommand == null)
+
+                    var bypass = GameMain.LuaCs.Hook.Call<bool?>("console.bypassClientSendCheck", firstCommand, matchingCommand) ?? false;
+                    if (matchingCommand == null || bypass)
                     {
                         //if the command is not defined client-side, we'll relay it anyway because it may be a custom command at the server's side
                         GameMain.Client.SendConsoleCommand(command);


### PR DESCRIPTION
This PR adds two hooks related to console.

Client-side hook `onClientConsoleCommand(string[] splitCommand, Command? command)` casts when user inputs command in console. If hook returns `true` value, command will be sent to server, ignoring client's permission check and `RelayToServer` flag.
1. `string[] splitCommand` is split version of command
2. `Command? command` is command as `Command`. Will be `nil` if command is unregistered

Server-side hook `onConsoleCommand(Client client, string[] splitCommand, Command? command, bool passedConsolePermissionCheck, bool passedCommandPermissionCheck)` casts when client tries to execute command in console. If hook returns `true` value, command will be executed, ignoring client permissions.
1. `Client client` that executes command
2. `string[] splitCommand` is split version of command
3. `Command? command` is command as `Command`. Will be `nil` if command is unregistered
4. `bool passedConsolePermissionCheck` will be `true` if client has `ConsoleCommands` permission
5. `bool passedCommandPermissionCheck` will be `true` if client has permission to execute this command. This will be `false` if command is unregistered.

These two hooks can be used in case if mod adds custom commands. Game tends to delete permissions to unregistered commands which applies to custom commands when they're not initialized yet. With these hooks, mod can check permissions for commands itself, i.e. by using it's own database with permissions.