### PR TITLE
Fix monomod in git builds

### DIFF
--- a/Barotrauma/BarotraumaClient/LinuxClient.csproj
+++ b/Barotrauma/BarotraumaClient/LinuxClient.csproj
@@ -131,6 +131,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonoMod.Core" Version="1.2.3" />
     <PackageReference Include="NVorbis" Version="0.8.6" />
     <PackageReference Include="RestSharp" Version="106.13.0" />
   </ItemGroup>

--- a/Barotrauma/BarotraumaServer/LinuxServer.csproj
+++ b/Barotrauma/BarotraumaServer/LinuxServer.csproj
@@ -79,6 +79,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonoMod.Core" Version="1.2.3" />
     <PackageReference Include="RestSharp" Version="106.13.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix to bug https://github.com/evilfactory/LuaCsForBarotrauma/issues/253 in automatic git builds by adding monomod 1.2.3 to nuget